### PR TITLE
Inclusive/exclusive filtering

### DIFF
--- a/cmd/pak-extracter/main.go
+++ b/cmd/pak-extracter/main.go
@@ -33,6 +33,7 @@ const (
 var (
 	pool           *workerpool.Pool
 	filters        map[string]bool
+	negatedFilters bool
 	inputPath      string
 	outputDir      string
 	hashSumFile    string
@@ -89,7 +90,11 @@ func main() {
 		log.Fatalf("filepath.Abs: %s", err)
 	}
 
-	filters = map[string]bool{}
+	filters = map[string]bool{}	
+	negatedFilters = strings.HasPrefix(*filterPtr, "!")
+	if negatedFilters {
+		*filterPtr = *(filterPtr)[1:]
+	}
 	filterParts := strings.Split(*filterPtr, ",")
 	for _, ext := range filterParts {
 		filters[fmt.Sprintf(".%s", strings.TrimPrefix(ext, "."))] = true
@@ -207,7 +212,7 @@ func addTask(id int64, pakFile *pak.Pak, file *pak.File) {
 		}
 
 		ext := filepath.Ext(file.Name)
-		if filters[ext] {
+		if filters[ext] != negatedFilters {
 			return nil
 		}
 		fpath := filepath.ToSlash(filepath.Clean(filepath.Join(outputDir, strings.ReplaceAll(filepath.Dir(pakFile.GetPath()), basePath, ""), file.Name)))

--- a/cmd/pak-extracter/main.go
+++ b/cmd/pak-extracter/main.go
@@ -93,7 +93,7 @@ func main() {
 	filters = map[string]bool{}	
 	negatedFilters = strings.HasPrefix(*filterPtr, "!")
 	if negatedFilters {
-		*filterPtr = *(filterPtr)[1:]
+		*filterPtr = (*filterPtr)[1:]
 	}
 	filterParts := strings.Split(*filterPtr, ",")
 	for _, ext := range filterParts {


### PR DESCRIPTION
This is my attempt at implementing inclusive filtering, in addition to the existing exclusive behaviour. If the list of extensions provided to `-filter` is prefixed with `!` then the filters will be processed inclusively.

_Note: for compatibility reason, the default behaviour remains exclusive._

Examples:
- `-filter .cfg,.xml` will extract everything but `.cfg` and `.xml` files
- `-filter !.cfg,.xml` will only extract `.cfg` and `.xml` files

Linked issue: [https://github.com/new-world-tools/new-world-tools/issues/4](https://github.com/new-world-tools/new-world-tools/issues/4)

I don't know if you accept PRs, but please be aware it's probably my first piece of code written in Go. I built a pre-release on my end to try this out ([v0.6.1](https://github.com/Nakda/new-world-tools/releases/tag/v0.6.1)), and I encourage you to double check. You might want to implement this feature in another way though, and if that's the case you can just discard this PR.